### PR TITLE
Fix use of `rx' macro

### DIFF
--- a/sx-question-mode.el
+++ b/sx-question-mode.el
@@ -345,11 +345,11 @@ HEADER is given `sx-question-mode-header' face, and value is given FACE.
     (when sx-question-mode-bullet-appearance
       (font-lock-add-keywords ;; Bullet items.
        nil
-       `(((rx line-start (0+ blank) (group-n 1 (any "*+-")) blank)
+       `((,(rx line-start (0+ blank) (group-n 1 (any "*+-")) blank)
           1 '(face nil display ,sx-question-mode-bullet-appearance) prepend))))
     (font-lock-add-keywords ;; Highlight usernames.
      nil
-     `(((rx (or blank line-start)
+     `((,(rx (or blank line-start)
             (group-n 1 (and "@" (1+ (or (syntax word) (syntax symbol)))))
             symbol-end)
         1 font-lock-builtin-face)))


### PR DESCRIPTION
It needs to be evaluated.

If we were imagining that it would expand the macro compile-time, I'm not sure we're doing that right now. If it's possible, I wouldn't be opposed to putting such a patch in this PR.
