### PR TITLE
Provide cache invalidation

### DIFF
--- a/sx-cache.el
+++ b/sx-cache.el
@@ -86,7 +86,7 @@ If SAVE-AUTH is non-nil, do not clear AUTH cache."
   (let ((caches (let ((default-directory sx-cache-directory))
                   (file-expand-wildcards "*.el"))))
     (when save-auth
-      (setq caches (remove-if (lambda (x)
+      (setq caches (cl-remove-if (lambda (x)
                                 (string= x "auth.el")) caches)))
     (lwarn 'stack-mode :debug "Invalidating: %S" caches)
     (mapc #'sx-cache--invalidate caches)


### PR DESCRIPTION
(sx-cache--invalidate): Invalidate provided cache.  Allows for
invalidating variables associated with cache using `makunbound`.  Cache
can be reinitialized using arg `init-method`.
(sx-cache-invalidate-all): Invalidate all caches then call
`sx-initialize` to reinitialize.  Arg `save-auth` prevents access_token
from being lost.
