### PR TITLE
Autoload sx-authenticate

### DIFF
--- a/sx-auth.el
+++ b/sx-auth.el
@@ -80,7 +80,8 @@ will be (METHOD  . t)")
 Keywords are of form (OBJECT TYPES) where TYPES is (FILTER FILTER
 FILTER).")
 
-(defun sx-auth-authenticate ()
+;;;###autoload
+(defun sx-authenticate ()
   "Authenticate this application.
 Authentication is required to read your personal data (such as
 notifications) and to write with the API (asking and answering
@@ -125,8 +126,6 @@ parsed and displayed prominently on the page)."
       (progn (setq sx-auth-access-token nil)
              (error "You must enter this code to use this client fully"))
     (sx-cache-set 'auth `((access_token . ,sx-auth-access-token)))))
-
-(defalias 'sx-authenticate #'sx-auth-authenticate)
 
 (defun sx-auth--method-p (method &optional submethod)
   "Check if METHOD is one that may require authentication.

--- a/sx-method.el
+++ b/sx-method.el
@@ -91,7 +91,7 @@ Return the entire response as a complex alist."
        ;; 1. Need auth and warn user (interactive use)
        ((and method-auth (equal 'warn auth))
         (user-error
-         "This request requires authentication.  Please run `M-x sx-auth-authenticate' and try again."))
+         "This request requires authentication.  Please run `M-x sx-authenticate' and try again."))
        ;; 2. Need auth to populate UI, cannot provide subset
        ((and method-auth auth)
         (setq call 'sx-request-fallback))


### PR DESCRIPTION
This also removes the sx-authenticate alias and renames
sx-auth-authenticate to sx-authenticate.

I did this because I felt it wasn't helpful to have both. Whenever I hit
`M-x sx-au <TAB>` the only completions offered were two identical, but
differently named, commands. That's useless at best, confusing at worst.
