### PR TITLE
Use package-file directive in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,14 +1,8 @@
-(package "stack-mode" "0" "Stack Exchange for Emacs")
-
 (source gnu)
 (source melpa-stable)
 
+(package-file "sx.el")
 (files "sx*.el")
-
-(depends-on "json" "1.4")
-(depends-on "url")
-(depends-on "cl-lib")
-(depends-on "markdown-mode")
 
 (development
  (depends-on "ert"))


### PR DESCRIPTION
No need to repeat the metadata which in sx.el: cask knows how to read it.
