### PR TITLE
Issue #157  zlib

### DIFF
--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -182,9 +182,6 @@ QUESTION must be a data structure returned by `json-read'."
     (mapc #'sx-question-mode--print-section .answers))
   (insert "\n\n                       ")
   (insert-text-button "Write an Answer" :type 'sx-button-answer)
-  ;; Display weird chars correctly
-  (set-buffer-multibyte nil)
-  (set-buffer-multibyte t)
   ;; Go up
   (goto-char (point-min))
   (sx-question-mode-next-section))


### PR DESCRIPTION
This uses the built-int zlib-decompress-region by default, and falls back on shell command only if necessary.

This also implements Stefan's suggestion [here](http://emacs.stackexchange.com/q/4100/50), which absolutely works. So we should accept his answer.
