### PR TITLE
Get all items

### DIFF
--- a/sx-request.el
+++ b/sx-request.el
@@ -95,10 +95,12 @@ number of requests left every time it finishes a call."
 
 ;;; Making Requests
 (defun sx-request-all-items (method &optional args request-method
-                                    stop-when process-function)
+                                    process-function stop-when delay)
   "Call METHOD with ARGS until there are no more items.
 STOP-WHEN is a function that takes the entire response and
-returns non-nil if the process should stop.
+returns non-nil if the process should stop.  DELAY is the number
+of seconds (possibly a float value) to wait after each request is
+made (to avoid throttling).  The default value is 0.25.
 
 All other arguments are identical to `sx-request-make', but
 PROCESS-FUNCTION is given the default value of `identity' (rather
@@ -118,6 +120,7 @@ access the response wrapper."
             return-value
             (vconcat return-value
                      (cdr (assoc 'items response))))
+      (sleep-for (or delay 0.25))
       (setq response
             (sx-request-make method `((page . ,current-page) ,@args)
                              request-method process-function)))

--- a/sx-request.el
+++ b/sx-request.el
@@ -100,7 +100,7 @@ It is good to use a reasonable delay to avoid rate-limiting.")
 
 ;;; Making Requests
 (defun sx-request-all-items (method &optional args request-method
-                                    process-function stop-when)
+                                    stop-when)
   "Call METHOD with ARGS until there are no more items.
 STOP-WHEN is a function that takes the entire response and
 returns non-nil if the process should stop.
@@ -115,7 +115,7 @@ access the response wrapper."
   (let* ((return-value [])
          (current-page 1)
          (stop-when (or stop-when #'sx-request-all-stop-when-no-more))
-         (process-function (or process-function #'identity))
+         (process-function #'identity)
          (response
           (sx-request-make method `((page . ,current-page) ,@args)
                            request-method process-function)))

--- a/sx-request.el
+++ b/sx-request.el
@@ -95,13 +95,13 @@ number of requests left every time it finishes a call."
 
 ;;; Making Requests
 
-(defun sx-request-make (method &optional args request-method)
+(defun sx-request-make (method &optional args request-method process-function)
   "Make a request to the API, executing METHOD with ARGS.
 You should almost certainly be using `sx-method-call' instead of
 this function. REQUEST-METHOD is one of `GET' (default) or `POST'.
 
-Returns cleaned response content.
-See (`sx-encoding-clean-content-deep').
+Returns the entire response as processed by PROCESS-FUNCTION.
+This defaults to `sx-request-response-get-items'.
 
 The full set of arguments is built with
 `sx-request--build-keyword-arguments', prepending
@@ -164,7 +164,8 @@ the main content of the response is returned."
                      sx-request-remaining-api-requests-message-threshold)
               (sx-message "%d API requests remaining"
                           sx-request-remaining-api-requests))
-            (sx-encoding-clean-content-deep .items)))))))
+            (funcall (or process-function #'sx-request-response-get-items)
+                       response)))))))
 
 (defun sx-request-fallback (_method &optional _args _request-method)
   "Fallback method when authentication is not available.
@@ -204,6 +205,13 @@ false, use the symbol `false'.  Each element is processed with
                   (when (cdr pair) pair))
                 alist))
      "&")))
+
+
+;;; Response Processors
+(defun sx-request-response-get-items (response)
+  "Returns the items from RESPONSE."
+  (sx-assoc-let response
+    (sx-encoding-clean-content-deep .items)))
 
 
 (provide 'sx-request)

--- a/sx-request.el
+++ b/sx-request.el
@@ -114,11 +114,11 @@ access the response wrapper."
           (sx-request-make method `((page . ,current-page) ,@args)
                            request-method process-function)))
     (while (not (funcall stop-when response))
-      (setq return-value
+      (setq current-page (1+ current-page)
+            return-value
             (vconcat return-value
                      (cdr (assoc 'items response))))
-      (setq current-page (1+ current-page)
-            response
+      (setq response
             (sx-request-make method `((page . ,current-page) ,@args)
                              request-method process-function)))
     (vconcat return-value

--- a/sx-request.el
+++ b/sx-request.el
@@ -108,6 +108,7 @@ than `sx-request-response-get-items') to allow STOP-WHEN to
 access the response wrapper."
   ;; @TODO: Refactor.  This is the product of a late-night jam
   ;; session...  it is not intended to be model code.
+  (declare (indent 1))
   (let* ((return-value [])
          (current-page 1)
          (stop-when (or stop-when #'sx-request-all-stop-when-no-more))
@@ -149,6 +150,7 @@ then read with `json-read-from-string'.
 
 `sx-request-remaining-api-requests' is updated appropriately and
 the main content of the response is returned."
+  (declare (indent 1))
   (let* ((url-automatic-caching t)
          (url-inhibit-uncompression t)
          (url-request-data (sx-request--build-keyword-arguments args nil))

--- a/sx-request.el
+++ b/sx-request.el
@@ -92,15 +92,18 @@ number of requests left every time it finishes a call."
   :group 'sx
   :type 'integer)
 
+(defvar sx-request-all-items-delay
+  1
+  "Delay in seconds with each `sx-request-all-items' iteration.
+It is good to use a reasonable delay to avoid rate-limiting.")
+
 
 ;;; Making Requests
 (defun sx-request-all-items (method &optional args request-method
-                                    process-function stop-when delay)
+                                    process-function stop-when)
   "Call METHOD with ARGS until there are no more items.
 STOP-WHEN is a function that takes the entire response and
-returns non-nil if the process should stop.  DELAY is the number
-of seconds (possibly a float value) to wait after each request is
-made (to avoid throttling).  The default value is 0.25.
+returns non-nil if the process should stop.
 
 All other arguments are identical to `sx-request-make', but
 PROCESS-FUNCTION is given the default value of `identity' (rather
@@ -121,7 +124,7 @@ access the response wrapper."
             return-value
             (vconcat return-value
                      (cdr (assoc 'items response))))
-      (sleep-for (or delay 0.25))
+      (sleep-for sx-request-all-items-delay)
       (setq response
             (sx-request-make method `((page . ,current-page) ,@args)
                              request-method process-function)))

--- a/test/test-api.el
+++ b/test/test-api.el
@@ -11,3 +11,8 @@
   (should-error
    (sx-request-make "questions" '(()))))
 
+(ert-deftest test-request-all ()
+  "Test request all items"
+  (should
+   (< 250
+      (length (sx-request-all-items "sites")))))

--- a/test/test-api.el
+++ b/test/test-api.el
@@ -16,3 +16,7 @@
   (should
    (< 250
       (length (sx-request-all-items "sites")))))
+
+(ert-deftest test-method-get-all ()
+  "Tests sx-method interface to `sx-request-all-items'"
+  (should (< 250 (sx-method-call 'sites :get-all t))))

--- a/test/test-api.el
+++ b/test/test-api.el
@@ -19,4 +19,4 @@
 
 (ert-deftest test-method-get-all ()
   "Tests sx-method interface to `sx-request-all-items'"
-  (should (< 250 (sx-method-call 'sites :get-all t))))
+  (should (< 250 (length (sx-method-call 'sites :get-all t)))))


### PR DESCRIPTION
Implement a means to get all pages of a method call. Can be used in `tag-bot`.