### PR TITLE
Don't assume .display_name exists. Fix #209

### DIFF
--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -276,7 +276,7 @@ DATA can represent a question or an answer."
 (defun sx-question-mode--propertize-display-name (author)
   "Return display_name of AUTHOR with `sx-question-mode-author' face."
   (sx-assoc-let author
-    (propertize .display_name
+    (propertize (or .display_name "??")
                 'face 'sx-question-mode-author)))
 
 (defun sx-question-mode--print-comment (comment-data)


### PR DESCRIPTION
This is a very quick fix so we can get it out.
I'm working on the function that will print usernames, which will improve the logic introduced here.
It'll also manually the `display_name` when the user posts a comment (since we know the name of the user).