### PR TITLE
Visit internally first

### DIFF
--- a/sx-button.el
+++ b/sx-button.el
@@ -100,7 +100,12 @@ usually part of a code-block."
   (interactive)
   (let ((url (or (get-text-property (or pos (point)) 'sx-button-url)
                  (sx-user-error "No url under point: %s" (or pos (point))))))
-    (sx-open-link url)))
+    ;; If we didn't recognize the link, this errors immediately.  If
+    ;; we mistakenly recognize it, it will error when we try to fetch
+    ;; whatever we thought it was.
+    (condition-case nil (sx-open-link url)
+      ;; When it errors, don't blame the user, just visit externally.
+      (error (sx-visit-externally url)))))
 
 
 ;;; Help-echo definitions

--- a/sx-button.el
+++ b/sx-button.el
@@ -98,9 +98,9 @@ usually part of a code-block."
 (defun sx-button-follow-link (&optional pos)
   "Follow link at POS.  If POS is nil, use `point'."
   (interactive)
-  (browse-url
-   (or (get-text-property (or pos (point)) 'sx-button-url)
-       (sx-user-error "No url under point: %s" (or pos (point))))))
+  (let ((url (or (get-text-property (or pos (point)) 'sx-button-url)
+                 (sx-user-error "No url under point: %s" (or pos (point))))))
+    (sx-open-link url)))
 
 
 ;;; Help-echo definitions


### PR DESCRIPTION
When hitting RET on a link, we try to visit it locally before resorting to browser. `v` still goes straight to browser. This builds on #231, so merge that first.