### PR TITLE
sx-method always uses a filter that includes all fields.

### DIFF
--- a/sx-compose.el
+++ b/sx-compose.el
@@ -241,7 +241,6 @@ respectively added locally to `sx-compose-before-send-hook' and
                                          (t 'answers))
                           :auth 'warn
                           :url-method 'post
-                          :filter sx-browse-filter
                           :site site
                           :keywords (sx-compose--generate-keywords is-question)
                           :id (or .comment_id .answer_id .question_id)
@@ -249,7 +248,6 @@ respectively added locally to `sx-compose-before-send-hook' and
               (lambda () (sx-method-call 'questions
                       :auth 'warn
                       :url-method 'post
-                      :filter sx-browse-filter
                       :site site
                       :keywords (sx-compose--generate-keywords is-question)
                       :id parent

--- a/sx-favorites.el
+++ b/sx-favorites.el
@@ -55,7 +55,6 @@ Added as hook to initialization."
   (sx-method-call 'me
     :submethod 'favorites
     :site site
-    :filter sx-favorite-list-filter
     :auth t))
 
 (defun sx-favorites--update-site-favorites (site)

--- a/sx-inbox.el
+++ b/sx-inbox.el
@@ -69,8 +69,7 @@ KEYWORDS are added to the method call along with PAGE.
 `sx-method-call' is used with `sx-inbox-filter'."
   (sx-method-call (if notifications 'notifications 'inbox)
     :keywords keywords
-    :page page
-    :filter sx-inbox-filter))
+    :page page))
 
 
 ;;; Major-mode

--- a/sx-interaction.el
+++ b/sx-interaction.el
@@ -236,8 +236,7 @@ With the UNDO prefix argument, unfavorite the question instead."
       :submethod (if undo 'favorite/undo 'favorite)
       :auth 'warn
       :site .site_par
-      :url-method 'post
-      :filter sx-browse-filter)))
+      :url-method 'post)))
 (defalias 'sx-star #'sx-favorite)
 
 
@@ -278,7 +277,6 @@ changes."
              :submethod (concat type (unless status "/undo"))
              :auth 'warn
              :url-method 'post
-             :filter sx-browse-filter
              :site .site_par))))
     ;; The api returns the new DATA.
     (when (> (length result) 0)
@@ -319,7 +317,6 @@ TEXT is a string. Interactively, it is read from the minibufer."
              :submethod "comments/add"
              :auth 'warn
              :url-method 'post
-             :filter sx-browse-filter
              :site .site_par
              :keywords `((body . ,text)))))
       ;; The api returns the new DATA.

--- a/sx-networks.el
+++ b/sx-networks.el
@@ -61,7 +61,6 @@ the variables."
                 (sx-method-call 'me
                   :submethod 'associated
                   :keywords '((types . (main_site meta_site)))
-                  :filter sx-network--user-filter
                   :auth t))
   (sx-network--get-associated))
 

--- a/sx-question.el
+++ b/sx-question.el
@@ -42,8 +42,7 @@ KEYWORDS are added to the method call along with PAGE.
     :keywords `((page . ,page) ,@keywords)
     :site site
     :auth t
-    :submethod submethod
-    :filter sx-browse-filter))
+    :submethod submethod))
 
 (defun sx-question-get-question (site question-id)
   "Query SITE for a QUESTION-ID and return it.
@@ -51,12 +50,11 @@ If QUESTION-ID doesn't exist on SITE, raise an error."
   (let ((res (sx-method-call 'questions
                :id question-id
                :site site
-               :auth t
-               :filter sx-browse-filter)))
+               :auth t)))
     (if (vectorp res)
         (elt res 0)
       (error "Couldn't find question %S in %S"
-             question-id site))))
+        question-id site))))
 
 (defun sx-question-get-from-answer (site answer-id)
   "Get question from SITE to which ANSWER-ID belongs.
@@ -65,12 +63,11 @@ If ANSWER-ID doesn't exist on SITE, raise an error."
                :id answer-id
                :site site
                :submethod 'questions
-               :auth t
-               :filter sx-browse-filter)))
+               :auth t)))
     (if (vectorp res)
         (elt res 0)
       (error "Couldn't find answer %S in %S"
-             answer-id site))))
+        answer-id site))))
 
 (defun sx-question-get-from-comment (site comment-id)
   "Get question from SITE to which COMMENT-ID belongs.
@@ -81,8 +78,7 @@ for the post."
   (let ((res (sx-method-call 'comments
                :id comment-id
                :site site
-               :auth t
-               :filter sx-browse-filter)))
+               :auth t)))
     (unless (vectorp res)
       (error "Couldn't find comment %S in %S" comment-id site))
     (sx-assoc-let (elt res 0)

--- a/sx-search.el
+++ b/sx-search.el
@@ -58,8 +58,7 @@ KEYWORDS is passed to `sx-method-call'."
                 (nottagged . ,excluded-tags)
                 ,@keywords)
     :site site
-    :auth t
-    :filter sx-browse-filter))
+    :auth t))
 
 
 ;;; User command

--- a/sx-site.el
+++ b/sx-site.el
@@ -44,8 +44,7 @@
   (sx-cache-get
    'site-list
    '(sx-method-call 'sites
-      :pagesize 999
-      :filter sx-site-browse-filter)))
+      :pagesize 999)))
 
 (defcustom sx-site-favorites
   nil

--- a/sx-tab.el
+++ b/sx-tab.el
@@ -252,8 +252,7 @@ If SITE is nil, use `sx-default-site'."
       :page page
       :site sx-question-list--site
       :auth t
-      :submethod 'favorites
-      :filter sx-browse-filter)))
+      :submethod 'favorites)))
 ;;;###autoload
 (autoload 'sx-tab-featured
   (expand-file-name

--- a/sx-tag.el
+++ b/sx-tag.el
@@ -43,7 +43,6 @@ If NO-SYNONYMS is non-nil, don't return synonyms."
                (append .synonyms so-far)))))
    (sx-method-call 'tags
      :get-all t
-     :filter sx-tag-filter
      :site site)
    :initial-value nil))
 
@@ -52,7 +51,6 @@ If NO-SYNONYMS is non-nil, don't return synonyms."
 Returns an array."
   (sx-method-call 'tags
     :auth nil
-    :filter sx-tag-filter
     :site site
     :keywords `((inname . ,string))))
 
@@ -95,7 +93,6 @@ Return the list of invalid tags in TAGS."
             :id (sx--thing-as-string tags)
             :submethod 'info
             :auth nil
-            :filter sx-tag-filter
             :site site))))
     (cl-remove-if (lambda (x) (member x result)) tags)))
 


### PR DESCRIPTION
This should fix our numerous API bugs, where incomplete objects were
being returned. For some reason, requiring completely unrelated filters
seems to affect the return of other filters.

I've kept the sx-filter file for now. But if we decide to follow this approach, that file might become unnecessary.