### PR TITLE
Issue 254  sorting options

### DIFF
--- a/sx-question-list.el
+++ b/sx-question-list.el
@@ -420,6 +420,10 @@ Non-interactively, DATA is a question alist."
   "Site being displayed in the *question-list* buffer.")
 (make-variable-buffer-local 'sx-question-list--site)
 
+(defvar sx-question-list--order nil
+  "Order being displayed in the *question-list* buffer.")
+(make-variable-buffer-local 'sx-question-list--order)
+
 (defun sx-question-list-refresh (&optional redisplay no-update)
   "Update the list of questions.
 If REDISPLAY is non-nil (or if interactive), also call `tabulated-list-print'.

--- a/sx-question-list.el
+++ b/sx-question-list.el
@@ -234,8 +234,10 @@ This is ignored if `sx-question-list--refresh-function' is set.")
   '(("Recent Activity" . activity)
     ("Creation Date"   . creation)
     ("Most Voted"      . votes)
+    ("Score"           . votes)
     ("Hot"             . hot))
   "Alist of possible values to be passed to the `sort' keyword.")
+(make-variable-buffer-local 'sx-question-list--order-methods)
 
 (defun sx-question-list--interactive-order-prompt (&optional prompt)
   "Interactively prompt for a sorting order.

--- a/sx-question-list.el
+++ b/sx-question-list.el
@@ -616,6 +616,19 @@ Sets `sx-question-list--site' and then call
     (setq sx-question-list--site site)
     (sx-question-list-refresh 'redisplay)))
 
+(defun sx-question-list-order-by (sort)
+  "Order questions in the current list by the method SORT.
+Sets `sx-question-list--order' and then calls
+`sx-question-list-refresh' with `redisplay'."
+  (interactive
+   (list (when sx-question-list--order
+           (sx-question-list--interactive-order-prompt))))
+  (unless sx-question-list--order
+    (sx-user-error "This list can't be reordered"))
+  (when (and sort (symbolp sort))
+    (setq sx-question-list--order sort)
+    (sx-question-list-refresh 'redisplay)))
+
 (provide 'sx-question-list)
 ;;; sx-question-list.el ends here
 

--- a/sx-question-list.el
+++ b/sx-question-list.el
@@ -259,6 +259,10 @@ The full list of variables which can be set is:
  5. `sx-question-list--dataset'
       This is only used if both 3 and 4 are nil. It can be used to
       display a static list.
+ 6. `sx-question-list--order'
+      Set this to the `sort' method that should be used when
+      requesting the list, if that makes sense. If it doesn't
+      leave it as nil.
 \\<sx-question-list-mode-map>
 If none of these is configured, the behaviour is that of a
 \"Frontpage\", for the site given by
@@ -282,7 +286,7 @@ Adding further questions to the bottom of the list is done by:
    display; otherwise, decrement `sx-question-list--pages-so-far'.
 
 If `sx-question-list--site' is given, items 3 and 4 should take it
-into consideration.
+into consideration.  The same holds for `sx-question-list--order'.
 
 \\{sx-question-list-mode-map}"
   (hl-line-mode 1)

--- a/sx-question-list.el
+++ b/sx-question-list.el
@@ -230,6 +230,22 @@ This is ignored if `sx-question-list--refresh-function' is set.")
     ": Quit")
   "Header-line used on the question list.")
 
+(defconst sx-question-list--order-methods
+  '(("Recent Activity" . activity)
+    ("Creation Date"   . creation)
+    ("Most Voted"      . votes)
+    ("Hot"             . hot))
+  "Alist of possible values to be passed to the `sort' keyword.")
+
+(defun sx-question-list--interactive-order-prompt (&optional prompt)
+  "Interactively prompt for a sorting order.
+PROMPT is displayed to the user.  If it is omitted, a default one
+is used."
+  (let ((order (sx-completing-read
+                (or prompt "Order questions by: ")
+                (mapcar #'car sx-question-list--order-methods))))
+    (cdr-safe (assoc-string order sx-question-list--order-methods))))
+
 
 ;;; Mode Definition
 (define-derived-mode sx-question-list-mode

--- a/sx-search.el
+++ b/sx-search.el
@@ -39,7 +39,9 @@
 
 
 ;;; Basic function
-(defun sx-search-get-questions (site page query &optional tags excluded-tags keywords)
+(defun sx-search-get-questions (site page query
+                                     &optional tags excluded-tags
+                                     &rest keywords)
   "Like `sx-question-get-questions', but restrict results by a search.
 
 Perform search on SITE.  PAGE is an integer indicating which page
@@ -108,7 +110,7 @@ prefix argument, the user is asked for everything."
             (sx-search-get-questions
              sx-question-list--site page
              query tags excluded-tags
-             `((sort . ,sx-question-list--order)))))
+             (cons 'sort sx-question-list--order))))
     (setq sx-question-list--site site)
     (setq sx-question-list--order sx-search-default-order)
     (setq sx-question-list--order-methods sx-search--order-methods)

--- a/sx-search.el
+++ b/sx-search.el
@@ -52,7 +52,6 @@ fail.  EXCLUDED-TAGS is only is used if TAGS is also provided.
 KEYWORDS is passed to `sx-method-call'."
   (sx-method-call 'search
     :keywords `((page . ,page)
-                (sort . activity)
                 (intitle . ,query)
                 (tagged . ,tags)
                 (nottagged . ,excluded-tags)
@@ -60,6 +59,16 @@ KEYWORDS is passed to `sx-method-call'."
     :site site
     :auth t
     :filter sx-browse-filter))
+
+(defconst sx-search--order-methods
+  (cons '("Relevance" . relevance)
+        (cl-remove-if (lambda (x) (eq (cdr x) 'hot))
+                      (default-value 'sx-question-list--order-methods)))
+  "Alist of possible values to be passed to the `sort' keyword.")
+
+(defvar sx-search-default-order 'activity 
+  "Default ordering method used on new searches.
+Possible values are the cdrs of `sx-search--order-methods'.")
 
 
 ;;;###autoload
@@ -98,8 +107,11 @@ prefix argument, the user is asked for everything."
           (lambda (page)
             (sx-search-get-questions
              sx-question-list--site page
-             query tags excluded-tags)))
+             query tags excluded-tags
+             `((sort . ,sx-question-list--order)))))
     (setq sx-question-list--site site)
+    (setq sx-question-list--order sx-search-default-order)
+    (setq sx-question-list--order-methods sx-search--order-methods)
     (sx-question-list-refresh 'redisplay)
     (switch-to-buffer (current-buffer))))
 


### PR DESCRIPTION
Fix #254
Ordering of searches. Can easily be extended to tabs, I was just slightly unsure of how to approach that since we already have one tab command for each ordering. 