### PR TITLE
Print question without temp buffer + async images!

### DIFF
--- a/sx-question-mode.el
+++ b/sx-question-mode.el
@@ -195,7 +195,7 @@ Letters do not insert themselves; instead, they are commands.
     (set-window-parameter
      nil 'quit-restore
      `(other window nil ,(current-buffer))))
-  ;; We call font-lock-region manually. See `sx-question-mode--fill-and-fontify'
+  ;; We call font-lock-region manually. See `sx-question-mode--insert-markdown'.
   (font-lock-mode -1)
   (remove-hook 'after-change-functions 'markdown-check-change-for-wiki-link t)
   (remove-hook 'window-configuration-change-hook

--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -427,7 +427,7 @@ Image links are downloaded and displayed, if
                      url))
                url)
               (when image-p
-                (sx-question-mode--create-image url (1- (point)))))))))))
+                (sx-question-mode--create-image url (- (point) 2))))))))))
 
 (defun sx-question-mode--create-image (url point)
   "Get and create an image from URL and insert it at POINT.
@@ -445,7 +445,8 @@ Its size is bound by `sx-question-mode-image-max-width' and
                        (list :width (min sx-question-mode-image-max-width
                                          (window-body-width nil 'pixel)
                                          image-width))))))))
-    (sx-request-get-url url callback)))
+    (sx-request-get-url url callback)
+    (overlay-put ov 'face 'default)))
 
 (defun sx-question-mode--insert-link (text url)
   "Return a link propertized version of TEXT-OR-IMAGE.
@@ -459,7 +460,7 @@ URL is used as 'help-echo and 'url properties."
       (forward-char 1)
       (delete-char 1)))
   ;; Images need to be at the start of a line.
-  (when (and imagep (not (looking-at-p "^")))
+  (unless (or text (looking-at-p "^"))
     (insert "\n"))
   (insert-text-button (or text " ")
                       ;; Mouse-over
@@ -472,7 +473,7 @@ URL is used as 'help-echo and 'url properties."
                       'sx-button-copy url
                       :type 'sx-button-link)
   ;; Images need to be at the end of a line too.
-  (insert "\n"))
+  (unless text (insert "\n")))
 
 (defun sx-question-mode-find-reference (id &optional fallback-id)
   "Find url identified by reference ID in current buffer.

--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -352,20 +352,26 @@ E.g.:
 This does not do Markdown font-locking.  Instead, it fills text,
 propertizes links, inserts images, cleans up html comments, and
 font-locks code-blocks according to mode."
-  (save-restriction
-    (save-excursion
-      (narrow-to-region beg end)
-      ;; Compact links.
-      (sx-question-mode--process-links-in-buffer)
-      ;; And now the filling and other handlings.
-      (goto-char (point-min))
-      (while (null (eobp))
-        ;; Don't fill pre blocks.
-        (unless (sx-question-mode--dont-fill-here)
-          (let ((beg (point)))
-            (skip-chars-forward "\r\n[:blank:]")
-            (forward-paragraph)
-            (fill-region beg (point))))))))
+  ;; Paragraph filling
+  (let ((paragraph-start
+         "\f\\|[ \t]*$\\|[ \t]*[*+-] \\|[ \t]*[0-9]+\\.[ \t]\\|[ \t]*: ")
+        (paragraph-separate "\\(?:[ \t\f]*\\|.* \\)$")
+        (adaptive-fill-first-line-regexp "\\`[ \t]*>[ \t]*?\\'")
+        (adaptive-fill-function #'markdown-adaptive-fill-function)) 
+    (save-restriction
+      (save-excursion
+        (narrow-to-region beg end)
+        ;; Compact links.
+        (sx-question-mode--process-links-in-buffer)
+        ;; And now the filling and other handlings.
+        (goto-char (point-min))
+        (while (null (eobp))
+          ;; Don't fill pre blocks.
+          (unless (sx-question-mode--dont-fill-here)
+            (let ((beg (point)))
+              (skip-chars-forward "\r\n[:blank:]")
+              (forward-paragraph)
+              (fill-region beg (point)))))))))
 
 (defun sx-question-mode--insert-markdown (text)
   "Return TEXT fontified according to `markdown-mode'."

--- a/test/test-printing.el
+++ b/test/test-printing.el
@@ -167,8 +167,9 @@ after being run through `sx-tag--format'."
   "Check complicated questions are filled correctly."
   (should
    (equal
-    (sx-question-mode--fill-and-fontify
-     "Creating an account on a new site requires you to log into that site using *the same credentials you used on existing sites.* For instance, if you used the Stack Exchange login method, you'd...
+    (with-temp-buffer
+      (sx-question-mode--insert-markdown
+       "Creating an account on a new site requires you to log into that site using *the same credentials you used on existing sites.* For instance, if you used the Stack Exchange login method, you'd...
 
 1. Click the \"Log in using Stack Exchange\" button:
 
@@ -192,6 +193,7 @@ after being run through `sx-tag--format'."
   [1]: http://i.stack.imgur.com/ktFTs.png
   [2]: http://i.stack.imgur.com/5l2AY.png
   [3]: http://i.stack.imgur.com/22myl.png")
+      (buffer-string))
     "Creating an account on a new site requires you to log into that site
 using *the same credentials you used on existing sites.* For instance,
 if you used the Stack Exchange login method, you'd...


### PR DESCRIPTION
This patch refactors fill-and-fontify to `insert-markdown`, which only uses a temp buffer for the fontification (where it's necessary). The filling and other handlings can be done in the question buffer, so we do that now.

As a side effect this means `insert-markdown` can add overlays to the buffer. 
For instance, we can finally implement #144. 
We can also have images which load asynchronously. In fact, I just did that! :-)