### PR TITLE
Updated markdown-code-at-point-p to markdown-inline-code-at-point-p

### DIFF
--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -572,7 +572,7 @@ font-locks code-blocks according to mode."
   "Return non-nil if point is inside code.
 This can be inline Markdown code or a Markdown code-block."
   (save-match-data
-    (or (markdown-code-at-point-p)
+    (or (markdown-inline-code-at-point-p)
         (save-excursion
           (sx-question-mode--skip-and-fontify-pre 'dont-fontify)))))
 


### PR DESCRIPTION
`markdown-code-at-point-p` was renamed in this commit: https://github.com/jrblevin/markdown-mode/commit/8cc6e00f9df400b40c3945189e4b44fcce7caae2