### PR TITLE
Fixes for byte compiler & update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - cask --version
 
 script:
+  - emacs  --eval "(setq byte-compile-error-on-warn (>= emacs-major-version 25))" -L .  --batch -f batch-byte-compile sx*.el
   - emacs --batch -L . -l ert -l test/tests.el -f ert-run-tests-batch-and-exit
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
   - EVM_EMACS=emacs-24.4-bin
+  - EVM_EMACS=emacs-25.3-bin
 
 before_install:
   - sudo mkdir /usr/local/evm

--- a/sx-encoding.el
+++ b/sx-encoding.el
@@ -152,10 +152,8 @@ numbers identifying the gzip file format.
 
 See URL `http://www.gzip.org/zlib/rfc-gzip.html'."
   ;; Credit: http://emacs.stackexchange.com/a/2978
-  (let ((unidata (string-as-unibyte data)))
-    (when (<= 2 (length unidata))
-      (equal (substring unidata 0 2)
-             (unibyte-string 31 139)))))
+  (equal (substring (encode-coding-string data 'no-conversion) 0 2)
+         (unibyte-string 31 139)))
 
 (defun sx-encoding-gzipped-buffer-p (buffer)
   "Check if BUFFER is gzip-compressed.

--- a/sx-inbox.el
+++ b/sx-inbox.el
@@ -57,10 +57,12 @@
   :group 'sx)
 
 (defface sx-inbox-item-type
-  '((t :inherit font-lock-keyword-face))  "")
+  '((t :inherit font-lock-keyword-face))  ""
+  :group 'sx)
 
 (defface sx-inbox-item-type-unread
-  '((t :inherit font-lock-keyword-face :weight bold)) "")
+  '((t :inherit font-lock-keyword-face :weight bold)) ""
+  :group 'sx)
 
 (defun sx-inbox-get (&optional notifications page keywords)
   "Get an array of inbox items for the current user.

--- a/sx-interaction.el
+++ b/sx-interaction.el
@@ -38,6 +38,7 @@
 ;;; Code:
 (eval-when-compile
   '(require 'cl-lib))
+(declare-function org-store-link-props "org")
 
 (require 'sx)
 (require 'sx-question)
@@ -88,7 +89,7 @@ REST is passed to `sx--data-here'."
     (apply #'sx--data-here rest)))
 
 (defun sx--error-if-unread (data)
-  "Throw a user-error if DATA is an unread question.
+  "Throw a `user-error' if DATA is an unread question.
 If it's not a question, or if it is read, return DATA."
   ;; If we found a question, we may need to check if it's read.
   (if (and (assoc 'title data)
@@ -122,13 +123,13 @@ be a question matching SITE and ID."
                (sx-question-mode-refresh 'no-update)))))))
 
 (defun sx--copy-data (from to)
-  "Copy all fields of alist FORM onto TO.
+  "Copy all fields of alist FROM onto TO.
 Only fields contained in TO are copied."
   (setcar to (car from))
   (setcdr to (cdr from)))
 
 (defun sx-ensure-authentication ()
-  "Signal user-error if the user refuses to authenticate.
+  "Signal `user-error' if the user refuses to authenticate.
 Note that `sx-method-call' already does authentication checking.
 This function is meant to be used by commands that don't
 immediately perform method calls, such as `sx-ask'.  This way,
@@ -137,7 +138,7 @@ the trouble of composing an entire question."
   (unless (sx-cache-get 'auth)
     (if (y-or-n-p "This command requires authentication, would you like to authenticate? ")
         (sx-authenticate)
-      (sx-user-error "This command requires authentication, please run `M-x sx-authenticate' and try again."))))
+      (sx-user-error "This command requires authentication, please run `M-x sx-authenticate' and try again"))))
 
 (defmacro sx--make-update-callback (&rest body)
   "Return a function that runs BODY and updates display.
@@ -172,7 +173,7 @@ argument passed to the function.  Then,
 DATA can be a question, answer, or comment. Interactively, it is
 derived from point position.
 
-If copy-as-kill is non-nil, do not call `browse-url'.
+If COPY-AS-KILL is non-nil, do not call `browse-url'.
 Instead, copy the link as a new kill with `kill-new'.
 Interactively, this is specified with a prefix argument.
 
@@ -245,7 +246,7 @@ Element can be a question, answer, or comment."
 Interactively, display object under point. Object can be a
 question, an answer, or an inbox_item.
 
-This is meant for interactive use. In lisp code, use
+This is meant for interactive use. In Lisp code, use
 object-specific functions such as `sx-display-question' and the
 likes."
   (interactive (list (sx--data-here)))
@@ -549,7 +550,7 @@ SITE is a string, indicating where the question will be posted."
 (defun sx-answer (data)
   "Start composing an answer for question given by DATA.
 DATA is a question alist. Interactively, it is guessed from
-context at point. "
+context at point."
   ;; If the user tries to answer a question that's not viewed, he
   ;; probaby hit the button by accident.
   (interactive

--- a/sx-site.el
+++ b/sx-site.el
@@ -52,6 +52,7 @@
   "List of favorite sites.
 Each entry is a string corresponding to a single site's
 api_site_parameter."
+  :type '(repeat string)
   :group 'sx)
 
 (defun sx-site-get-api-tokens ()

--- a/sx.el
+++ b/sx.el
@@ -28,6 +28,9 @@
 ;;; Code:
 (require 'tabulated-list)
 
+(declare-function magithub-issue-new "magithub-issue-post")
+(declare-function magithub-repo "magithub-core")
+
 (defconst sx-version "0.3" "Version of the `sx' package.")
 
 (defgroup sx nil


### PR DESCRIPTION
Various fixes so the byte compiler is satisfied, a few checkdoc fixes. 

`string-as-unibyte` is obsolete in upcoming Emacs 26, Can you double-check that `(encode-coding-string data 'no-conversion)` is right?