### PR TITLE
Show question title on dedicated inbox line

### DIFF
--- a/sx-inbox.el
+++ b/sx-inbox.el
@@ -170,7 +170,7 @@ is an alist containing the elements:
        'face (if .is_unread 'sx-inbox-item-type-unread 'sx-inbox-item-type))
       (list
        (concat (sx-time-since .creation_date)
-               sx-question-list-ago-string)
+               sx-question-list-ago-string "\n")
        'face 'sx-question-list-date)
       (list
        (propertize " " 'display


### PR DESCRIPTION
* The default display orientation of the sx-inbox window is thin (~20%
  screen width), so the question title isn't visible> Alternatively,
  one could enable `visual-line-mode' for the buffer, but that could
  potentially get messy. Also, in this buffer `C-e`' does not advance
  to the end of the line to be able to view the data.