### PR TITLE
Make inbox window dedicated to inbox buffer

### DIFF
--- a/sx-inbox.el
+++ b/sx-inbox.el
@@ -207,7 +207,8 @@ With prefix NOTIFICATIONS, list notifications instead of inbox."
       (pop-to-buffer sx-inbox--buffer)
       (enlarge-window
        (- (+ fill-column 4) (window-width))
-       'horizontal))))
+       'horizontal)
+      (set-window-dedicated-p w t))))
 
 ;;;###autoload
 (defun sx-inbox-notifications ()


### PR DESCRIPTION
* This solves display glitches, such as when focus is in the main sx
  window, and pressing `?', the help window would display in the inbox
  window, permanently changing its size.