### PR TITLE
Fix typo on README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ include:
 SX is now available on MELPA!  Both the stable release and the development
 version can be found there.  Install it via the Package Menu or just run
 #+BEGIN_SRC text
-M-x package-install RET sx RET=
+M-x package-install RET sx RET
 #+END_SRC
 
 ** Authenticating


### PR DESCRIPTION
Remove an extra "=" at the end of the installation instruction.