### PR TITLE
Fix: lwarn expects symbol or list (not string)

### DIFF
--- a/sx-auth.el
+++ b/sx-auth.el
@@ -148,7 +148,7 @@ If it has `auth-required' SUBMETHODs, or no submethod, return t."
         ;; eligible, in which case we only need to check the `car'.
         (sub-head (if (listp submethod)
                       (car submethod))))
-    (lwarn " sx-auth method" :debug "Method %s requires auth" method-auth)
+    (lwarn '(sx-auth method) :debug "Method %s requires auth" method-auth)
     (and method-auth
          (or
           ;; All submethods require auth.
@@ -175,7 +175,7 @@ removed those properties."
                                                   sx-auth-filter-auth)))
                                        (or incl-filter filter))))
          clean-filter out-filter)
-    (lwarn "sx-auth filter" :debug "Filter: %S" filter)
+    (lwarn '(sx-auth filter) :debug "Filter: %S" filter)
     ;; Auth-filters is the filters that are issues
     (when auth-filters
       (setq clean-filter
@@ -186,7 +186,7 @@ removed those properties."
         (setq out-filter
               (cons clean-filter rest-filter))
       (setq out-filter clean-filter))
-    (lwarn "sx-auth filter2" :debug "Filter property %s requires auth. %S"
+    (lwarn '(sx-auth filter2) :debug "Filter property %s requires auth. %S"
            auth-filters out-filter)
     out-filter))
 

--- a/sx-method.el
+++ b/sx-method.el
@@ -114,7 +114,7 @@ Return the entire response as a complex alist."
          (cond
           ((eq get-all t) #'sx-request-all-stop-when-no-more)
           (t get-all))))
-    (lwarn "sx-call-method" :debug "A: %S T: %S. M: %S,%s. F: %S" (equal 'warn auth)
+    (lwarn '(sx-call-method) :debug "A: %S T: %S. M: %S,%s. F: %S" (equal 'warn auth)
            access-token method-auth full-method filter-auth)
     (unless access-token
       (cond


### PR DESCRIPTION
This bug looks a little weird to me, because I can not find any changes to `lwarn` in the Emacs commit history nor in the sx.el commit history. However, Emacs expects the first argument of lwarn to be a symbol or a list (and currently errors because the first argument is a string, so that sx.el basic functionality is broken). This commit fixes that.

I am not sure how `lwarn` used to work with strings as I can not easily find any information about that, but I just converted the string into a list which seems appropriate to me (from reading the `lwarn` docstring).